### PR TITLE
Update lib/csv-mapper/row_map.rb

### DIFF
--- a/lib/csv-mapper/row_map.rb
+++ b/lib/csv-mapper/row_map.rb
@@ -98,7 +98,7 @@ module CsvMapper
       self.add_filters(@before_filters, *befores)
     end
   
-    # Declare method name symbols and/or lambdas to be executed before each row.
+    # Declare method name symbols and/or lambdas to be executed after each row.
     # Each method or lambda must accept to parameters: +csv_row+, +target_object+
     # Methods names should refer to methods available within the RowMap's provided context
     def after_row(*afters)


### PR DESCRIPTION
The description of after_row contained a copy'n'paste error (before instead of after) which was obviously a leftover from copying the description from before_row.
